### PR TITLE
Refactor .gitignore to use wildcard patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 # === ROS 2 Build Files ===
-build/
-install/
-log/
-src/build
+*build/
+*install/
+*log/
 # === CMake and Colcon Caches ===
 CMakeCache.txt
 CMakeFiles/
@@ -28,4 +27,3 @@ __pycache__/
 
 # VS C
 
-src/build/


### PR DESCRIPTION
Updated .gitignore to use wildcard patterns for build, install, and log directories.