### PR TITLE
Cuda test node

### DIFF
--- a/src/snappy_cpp/CMakeLists.txt
+++ b/src/snappy_cpp/CMakeLists.txt
@@ -19,6 +19,10 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(OpenCV REQUIRED)
+find_package(CUDA REQUIRED)
+link_directories(/usr/local/cuda/targets/aarch64-linux/lib)
+
+find_library(NVINFER nvinfer PATHS /usr/lib/aarch64-linux-gnu)
 
 # Build all executables
 set(BOOST_ROOT "/usr")
@@ -30,6 +34,11 @@ ament_target_dependencies(serial_lib rclcpp std_msgs)
 add_executable(snappy_cpp src/test.cpp)
 ament_target_dependencies(snappy_cpp rclcpp std_msgs)
 target_link_libraries(snappy_cpp ${Boost_LIBRARIES})
+
+add_executable(cuda src/cuda.cpp)
+target_include_directories(cuda PRIVATE /usr/lib/aarch64-linux-gnu /usr/local/cuda/include)
+ament_target_dependencies(cuda rclcpp std_msgs)
+target_link_libraries(cuda ${NVINFER} ${CUDA_LIBRARIES} ${OpenCV_LIBS} /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcudart.so)
 
 add_executable(pressureSensor src/pressure_sensor.cpp)
 ament_target_dependencies(pressureSensor rclcpp std_msgs)
@@ -64,6 +73,7 @@ install(TARGETS
   planner
   counter_publisher
   snappy_cpp
+  cuda
   DESTINATION lib/${PROJECT_NAME})
 
 # Install launch files

--- a/src/snappy_cpp/CMakeLists.txt
+++ b/src/snappy_cpp/CMakeLists.txt
@@ -10,6 +10,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+option(WITH_CUDA "Build with CUDA and TensorRT support" ON)
+option(BUILD_TESTING "Build tests" OFF)
+
 include_directories(${Boost_INCLUDE_DIRS})
 
 find_package(ament_cmake REQUIRED)
@@ -19,10 +22,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(OpenCV REQUIRED)
-find_package(CUDA REQUIRED)
-link_directories(/usr/local/cuda/targets/aarch64-linux/lib)
-
-find_library(NVINFER nvinfer PATHS /usr/lib/aarch64-linux-gnu)
 
 # Build all executables
 set(BOOST_ROOT "/usr")
@@ -34,11 +33,6 @@ ament_target_dependencies(serial_lib rclcpp std_msgs)
 add_executable(snappy_cpp src/test.cpp)
 ament_target_dependencies(snappy_cpp rclcpp std_msgs)
 target_link_libraries(snappy_cpp ${Boost_LIBRARIES})
-
-add_executable(cuda src/cuda.cpp)
-target_include_directories(cuda PRIVATE /usr/lib/aarch64-linux-gnu /usr/local/cuda/include)
-ament_target_dependencies(cuda rclcpp std_msgs)
-target_link_libraries(cuda ${NVINFER} ${CUDA_LIBRARIES} ${OpenCV_LIBS} /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcudart.so)
 
 add_executable(pressureSensor src/pressure_sensor.cpp)
 ament_target_dependencies(pressureSensor rclcpp std_msgs)
@@ -63,6 +57,23 @@ ament_target_dependencies(planner rclcpp std_msgs geometry_msgs)
 add_executable(counter_publisher src/counter_publisher.cpp)
 ament_target_dependencies(counter_publisher rclcpp std_msgs)
 
+if(WITH_CUDA)
+  find_package(CUDA REQUIRED)
+  link_directories(/usr/local/cuda/targets/aarch64-linux/lib)
+
+  find_library(NVINFER nvinfer PATHS /usr/lib/aarch64-linux-gnu)
+
+  add_executable(cuda src/cuda.cpp)
+  target_include_directories(cuda PRIVATE /usr/lib/aarch64-linux-gnu /usr/local/cuda/include)
+  ament_target_dependencies(cuda rclcpp std_msgs)
+  target_link_libraries(cuda
+    ${NVINFER}
+    ${CUDA_LIBRARIES}
+    ${OpenCV_LIBS}
+    /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcudart.so
+  )
+endif()
+
 # Install all executables
 install(TARGETS
   pressureSensor
@@ -73,21 +84,21 @@ install(TARGETS
   planner
   counter_publisher
   snappy_cpp
-  cuda
   DESTINATION lib/${PROJECT_NAME})
+
+if(WITH_CUDA)
+  install(TARGETS cuda
+    DESTINATION lib/${PROJECT_NAME})
+endif()
 
 # Install launch files
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}/)
 
-
-option(BUILD_TESTING "Build tests" OFF)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  # Add gtest executables
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(unit_tests tests/test_serial.cpp)
   ament_target_dependencies(unit_tests rclcpp)

--- a/src/snappy_cpp/CMakeLists.txt
+++ b/src/snappy_cpp/CMakeLists.txt
@@ -10,7 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-option(WITH_CUDA "Build with CUDA and TensorRT support" ON)
+option(WITH_CUDA "Build with CUDA and TensorRT support" OFF)
 option(BUILD_TESTING "Build tests" OFF)
 
 include_directories(${Boost_INCLUDE_DIRS})

--- a/src/snappy_cpp/src/computer_vision.cpp
+++ b/src/snappy_cpp/src/computer_vision.cpp
@@ -98,7 +98,7 @@ private:
 
 	cv::Scalar minBGR = cv::Scalar(bgrPixel.val[0] - thresh, bgrPixel.val[1] - thresh, bgrPixel[2] - thresh);
 	cv::Scalar maxBGR = cv::Scalar(bgrPixel.val[0] + thresh, bgrPixel.val[1] + thresh, bgrPixel[2] + thresh);
-
+	std::cout << "minBGR: " << minBGR << ", maxBGR: " << maxBGR << std::endl;
     }
 
 

--- a/src/snappy_cpp/src/controller.cpp
+++ b/src/snappy_cpp/src/controller.cpp
@@ -42,7 +42,7 @@ private:
 
         auto msg = std_msgs::msg::Float32MultiArray();
 	if (flag_ < 40) {
-		msg.data = {1.0, 20.0 + float(flag_)};
+		msg.data = {1.0, 20.0 + static_cast<float>(flag_)};
 		flag_++;
 	} else {
 		msg.data = {255.0, 0.0};

--- a/src/snappy_cpp/src/controller.cpp
+++ b/src/snappy_cpp/src/controller.cpp
@@ -16,10 +16,20 @@ public:
     {
         pub_ = create_publisher<std_msgs::msg::Float32MultiArray>("/motor_cmd", 10);
         timer_ = create_wall_timer(100ms, std::bind(&Controller::publish_cmd, this));
+	flag_ = 0;
 
         // Declare parameters so they can be set from the command line or launch file
-        this->declare_parameter("motor_select", 255.0);  // default: all 8 motors
-        this->declare_parameter("speed", 0.0);            // default: stopped
+        //this->declare_parameter("motor_select", 255.0);  // default: all 8 motors
+        //this->declare_parameter("speed", 0.0);            // default: stopped
+
+	//auto msg = std_msgs::msg::Float32MultiArray();
+	//RCLCPP_INFO(get_logger(), "On");
+	//msg.data = {68.0, 20};
+	//pub_->publish(msg);
+	//rclcpp::sleep_for(std::chrono::seconds(1));
+	//RCLCPP_INFO(get_logger(), "Off");
+	//msg.data = {255.0, 0};
+	//pub_->publish(msg);
 
         RCLCPP_INFO(get_logger(), "Controller started — publishing on /motor_cmd at 10 Hz");
     }
@@ -27,18 +37,25 @@ public:
 private:
     void publish_cmd()
     {
-        double motor_select = this->get_parameter("motor_select").as_double();
-        double speed = this->get_parameter("speed").as_double();
+        //double motor_select = this->get_parameter("motor_select").as_double();
+        //double speed = this->get_parameter("speed").as_double();
 
         auto msg = std_msgs::msg::Float32MultiArray();
-        msg.data = {static_cast<float>(motor_select), static_cast<float>(speed)};
+	if (flag_ < 40) {
+		msg.data = {1.0, 20.0 + float(flag_)};
+		flag_++;
+	} else {
+		msg.data = {255.0, 0.0};
+	}
+        //msg.data = {static_cast<float>(motor_select), static_cast<float>(speed)};
         pub_->publish(msg);
 
-        RCLCPP_INFO(get_logger(), "Publishing: motors=%.0f speed=%.1f", motor_select, speed);
+        //RCLCPP_INFO(get_logger(), "Publishing: motors=%.0f speed=%.1f", motor_select, speed);
     }
 
     rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_;
     rclcpp::TimerBase::SharedPtr timer_;
+    int flag_;
 };
 
 int main(int argc, char * argv[])

--- a/src/snappy_cpp/src/cuda.cpp
+++ b/src/snappy_cpp/src/cuda.cpp
@@ -1,0 +1,83 @@
+#include <opencv2/core/check.hpp>
+#include <opencv2/core/cuda.hpp>
+#include <opencv2/core/utility.hpp>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
+#include <chrono>
+#include <NvInferRuntime.h>
+#include <cuda_runtime.h>
+
+class CudaNode : public rclcpp::Node
+{
+public:
+    CudaNode() : Node("cuda_node")
+    {
+        // temporary placeholder
+        RCLCPP_INFO(get_logger(), "=== CUDA + Tensor RT Check ===");
+        checkCUDA();
+        checkTensorRT();
+    }
+
+
+    private:
+    class TRTLogger : public nvinfer1::ILogger {
+        public:
+            rclcpp::Logger ros_logger;
+            TRTLogger(rclcpp::Logger logger) : ros_logger(logger) {}
+            void log(Severity severity, const char* msg) noexcept override {
+                if (severity < Severity::kWARNING) {
+                    RCLCPP_WARN(ros_logger, "[TRT] %s", msg);
+                }
+            }
+    };
+
+    void checkCUDA() {
+        int deviceCount;
+        cudaError_t err = cudaGetDeviceCount(&deviceCount);
+        if (err != cudaSuccess) {
+            RCLCPP_ERROR(this->get_logger(), "Failed to get device count: %s", cudaGetErrorString(err));
+            return;
+        }
+
+        RCLCPP_INFO(this->get_logger(), "Found %d CUDA devices", deviceCount);
+
+        if (deviceCount == 0) {
+            RCLCPP_ERROR(this->get_logger(), "No CUDA devices found ❌");
+            return;
+        }
+        cudaDeviceProp prop;
+        cudaGetDeviceProperties(&prop, 0);
+        RCLCPP_INFO(get_logger(), "GPU: %s", prop.name);
+        RCLCPP_INFO(get_logger(), "Compute capability: %d.%d", prop.major, prop.minor);
+        RCLCPP_INFO(get_logger(), "GPU Memory: %zu MB", prop.totalGlobalMem / (1024 * 1024));
+        RCLCPP_INFO(get_logger(), "CUDA: OK ✅");
+    }
+
+    void checkTensorRT() {
+        TRTLogger trt_logger(get_logger());
+        auto runtime = nvinfer1::createInferRuntime(trt_logger);
+
+        if (!runtime) {
+            RCLCPP_ERROR(get_logger(), "TensorRT runtime creation FAILED ❌");
+            return;
+        }
+
+        RCLCPP_INFO(get_logger(), "TensorRT version: %d.%d.%d",
+            NV_TENSORRT_MAJOR,
+            NV_TENSORRT_MINOR,
+            NV_TENSORRT_PATCH);
+        RCLCPP_INFO(get_logger(), "TensorRT runtime: OK ✅");
+
+        delete runtime;
+    }
+};
+
+int main(int argc, char *argv[])
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<CudaNode>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
This pull request adds optional CUDA and TensorRT support to the project, including a new ROS 2 node for runtime checks, and modifies the controller logic for motor command publishing, that was edited at our pool test on March 1st 2025

**Build system enhancements:**

* Added `WITH_CUDA` CMake option to enable/disable CUDA and TensorRT support, with associated build and install logic for the new CUDA node. [[1]](diffhunk://#diff-6fcfccb44111fdaeeb68ffe761343bd0907cea71225035e27aa54e5a42ed54ddR13-R15) [[2]](diffhunk://#diff-6fcfccb44111fdaeeb68ffe761343bd0907cea71225035e27aa54e5a42ed54ddR60-R76) [[3]](diffhunk://#diff-6fcfccb44111fdaeeb68ffe761343bd0907cea71225035e27aa54e5a42ed54ddR89-L80)
* Added `BUILD_TESTING` CMake option to control test building, now grouped with other options. [[1]](diffhunk://#diff-6fcfccb44111fdaeeb68ffe761343bd0907cea71225035e27aa54e5a42ed54ddR13-R15) [[2]](diffhunk://#diff-6fcfccb44111fdaeeb68ffe761343bd0907cea71225035e27aa54e5a42ed54ddR89-L80)

**New features:**

* Introduced new `cuda.cpp` node implementing a ROS 2 node that checks for CUDA device availability and TensorRT runtime status at startup. 
Future scope: this file will change within the coming weeks, running our .onnx trained model for yolo26, and eventually publishing the data from our computer vision system to our mission controller/planner node
